### PR TITLE
Performance optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+*.svg
+*.data
+*.old

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 
 [[package]]
 name = "cfg-if"
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7649a0b3ffb32636e60c7ce0d70511eda9c52c658cd0634e194d5a19943aeff"
+checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
 dependencies = [
  "rand",
  "secp256k1-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,9 @@ authors = ["Francisco Calderón <fjcalderon@gmail.com>"]
 
 [dependencies]
 bitcoin_hashes = "0.11.0"
-secp256k1 = { version = "0.24.0", features = ["rand-std"] }
+secp256k1 = { version = "0.24.1", features = ["rand-std"] }
 num_cpus = "1.1"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use secp256k1::rand::rngs::OsRng;
+use secp256k1::rand::thread_rng;
 use secp256k1::Secp256k1;
 use std::cmp::max;
 use std::env;
@@ -31,8 +31,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Benchmarking a single core for 5 seconds...");
     let now = Instant::now();
     let secp = Secp256k1::new();
+    let mut rng = thread_rng();
     loop {
-        let (_secret_key, public_key) = secp.generate_keypair(&mut OsRng);
+        let (_secret_key, public_key) = secp.generate_keypair(&mut rng);
         let (xonly_public_key, _) = public_key.x_only_public_key();
         let _leading_zeroes = get_leading_zero_bits(&xonly_public_key.serialize());
         hashes_per_second_per_core += 1;
@@ -58,12 +59,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     for _ in 0..cores {
         let best = best.clone();
         thread::spawn(move || {
+            let mut rng = thread_rng();
             let secp = Secp256k1::new();
             let mut iterations = 0;
             loop {
                 iterations += 1;
 
-                let (secret_key, public_key) = secp.generate_keypair(&mut OsRng);
+                let (secret_key, public_key) = secp.generate_keypair(&mut rng);
                 let (xonly_public_key, _) = public_key.x_only_public_key();
                 let leading_zeroes = get_leading_zero_bits(&xonly_public_key.serialize());
                 if leading_zeroes > best.load(Ordering::Relaxed) {


### PR DESCRIPTION
I benchmarked with cargo-flamegraph using `flamegraph --bin rana` (but don't let this run too long), and it's pretty clear the primary performance bottleneck is the secp256k1 library, which is not unexpected. ECs are somewhat computationally expensive. I attempted some performance optimizations on the crate itself, but that ran into some issues, so I opened an issue here: https://github.com/rust-bitcoin/rust-secp256k1/issues/533

I also briefly experimented with using the [k256](https://docs.rs/k256/0.11.6/k256/) library, but it was dog slow. Not worth it at all.

Additionally, I added atomic operations for measuring iterations across the entire system, but this will have a certain performance impact, about as much as a CPU cache miss, so, could be significant, but without decent measurements, it's difficult to optimize performance. Maybe this can be stripped out using conditional compilation if sheer performance is desired, with no regard for performance stats.

I recommend compiling it with these commands for maximum performance:
`RUSTFLAGS="-Ctarget-cpu=native" cargo build --release && cargo strip && target/release/rana`