### PR TITLE
Include npub/nsec format when printing keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "bitcoin_hashes"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,7 +78,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 name = "rana"
 version = "0.1.2"
 dependencies = [
+ "bech32",
  "bitcoin_hashes",
+ "hex",
  "num_cpus",
  "secp256k1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,9 @@ license = "MIT"
 authors = ["Francisco Calderón <fjcalderon@gmail.com>"]
 
 [dependencies]
+bech32 = "*"
 bitcoin_hashes = "0.11.0"
+hex = "*"
 secp256k1 = { version = "0.24.1", features = ["rand-std"] }
 num_cpus = "1.1"
 


### PR DESCRIPTION
Extend the console output to include the keys in `npub`/`nsec` format.

This format is used by some Nostr apps because it's better UX[^1] than the keys in hex. The prefix makes it clear to the user which key it is (the public or the secret one).

Conversion (back to hex) can be checked with https://damus.io/key/

[^1]: https://nostr.com/e/356de2e71f94847fd55dff8582ddd9b09ea63b0addf8a4652793741a35859c79