### PR TITLE
Ability to calculate vanity public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Mine public keys that can be used with nostr.
 
 This is based on [nip13](https://github.com/ok300/nostr-rs/blob/master/examples/nip13.rs) example.
 
-Provide the desired difficulty as the last argument. See:
-
-![Screenshot](screenshot.png)
+Provide the desired difficulty or the vanity prefix as arguments. See below.
 
 ## Requirements:
 
@@ -34,5 +32,13 @@ $ cargo run --release
 By default it will generate a public key with a difficulty of `10` but you can enter your difficulty as a parameter and be patient if you enter a bigger number.
 
 ```bash
-$ cargo run --release 20
+$ cargo run -- --difficulty=20
 ```
+
+Additionally you can specify a vanity prefix (hexadecimal characters) with the corresponding argument:
+
+```bash
+$ cargo run -- --vanity=dead
+```
+
+Keep in mind that you cannot specify a difficulty and a vanity prefix at the same time.

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut pow_difficulty = difficulty;
 
     if vanity_prefix != "" {
-        // set pow difficulty as the lenght of the prefix
-        pow_difficulty = vanity_prefix.len() as u8;
+        // set pow difficulty as the length of the prefix translated to bits
+        pow_difficulty = (vanity_prefix.len() * 4) as u8;
         println!(
             "Started mining process for a vanify prefix of: {} (pow: {})",
             vanity_prefix, pow_difficulty
@@ -59,7 +59,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("A single core can mine roughly {hashes_per_second_per_core} h/s!");
 
     let estimated_hashes = 2_u128.pow(pow_difficulty as u32);
-    println!("Searching for prefix of {pow_difficulty} zero bits");
+    println!("Searching for prefix of {pow_difficulty} specific bits");
     let estimate = estimated_hashes as f32 / hashes_per_second_per_core as f32 / cores as f32;
     println!("This is estimated to take about {estimate} seconds");
 
@@ -116,9 +116,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                     );
 
                     best_diff.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |_| {
-                        Some(leading_zeroes)
-                    })
-                    .unwrap();
+                            Some(leading_zeroes)
+                        })
+                        .unwrap();
                 }
             }
         });
@@ -208,8 +208,8 @@ fn parse_args() -> CliParsedArgs {
     if parsed_args.difficulty > 0 && parsed_args.vanity_prefix != "" {
         panic!("You cannot set a difficulty and a vanity prefix at the same time.");
     }
-    if parsed_args.vanity_prefix.len() > 255 {
-        panic!("The vanity prefix cannot be longer than 255 characters.");
+    if parsed_args.vanity_prefix.len() > 32 {
+        panic!("The vanity prefix cannot be longer than 32 characters.");
     }
 
     // println!("Diff: {}", cli_args.difficulty);


### PR DESCRIPTION
This PR adds the ability to mine public keys based on a specified vanity prefix.
In order to do this the CLI arguments were also changed, now they need to be passed as named arguments like this:
```bash
$ cargo run -- --difficulty=20
$ cargo run -- --vanity=dead
```

The README was updated to match this (the screenshot was removed because it showed the old ways).

PS: This is my first interaction with Rust... ever. Feel free to suggest better practices or fixes. Be merciful... or not 😈.