### PR TITLE
Vanity prefix for npub format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "num_cpus"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +97,7 @@ dependencies = [
  "bitcoin_hashes",
  "hex",
  "num_cpus",
+ "regex",
  "secp256k1",
 ]
 
@@ -114,6 +130,23 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "regex"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "secp256k1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Francisco Calderón <fjcalderon@gmail.com>"]
 bech32 = "*"
 bitcoin_hashes = "0.11.0"
 hex = "*"
+regex = "1"
 secp256k1 = { version = "0.24.1", features = ["rand-std"] }
 num_cpus = "1.1"
 

--- a/README.md
+++ b/README.md
@@ -29,16 +29,36 @@ $ cd rana
 $ cargo run --release
 ```
 
-By default it will generate a public key with a difficulty of `10` but you can enter your difficulty as a parameter and be patient if you enter a bigger number.
+By default it will generate a public key with a difficulty of `10` but you can customize its difficulty or vanity prefix with the proper parameters.
 
-```bash
-$ cargo run -- --difficulty=20
+Usage:
+```
+  OPTIONS
+
+      --difficulty <bits>   Enter the number of starting bits that should be 0.
+
+      --vanity <prefix>     Enter the prefix your public key should have when expressed 
+                            as hexadecimal.
+                            This can be combined with --vanity-n, but beware of extra
+                            calculations required.
+
+      --vanity-n <prefix>   Enter the prefix your public key should have when expressed 
+                            in npub format (Bech32 encoding).
+                            This can be combined with --vanity, but beware of extra
+                            calculations required.
+
+
 ```
 
-Additionally you can specify a vanity prefix (hexadecimal characters) with the corresponding argument:
+Examples:
 
 ```bash
-$ cargo run -- --vanity=dead
+$ cargo run --release -- --difficulty=20
+
+$ cargo run --release -- --vanity=dead
+
+$ cargo run --release -- --vanity-n=rana
 ```
 
 Keep in mind that you cannot specify a difficulty and a vanity prefix at the same time.
+Also, the more requirements you have, the longer it will take to reach a satisfactory public key.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use bech32::{ToBase32, Variant};
 use bitcoin_hashes::hex::ToHex;
+use regex::Regex;
 use secp256k1::rand::thread_rng;
 use secp256k1::{Secp256k1, SecretKey, XOnlyPublicKey};
 use std::cmp::max;
@@ -28,6 +29,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             vanity_prefix, pow_difficulty
         );
     } else {
+        // Defaults to using difficulty
         if difficulty == 0 {
             difficulty = 10; // default
             pow_difficulty = difficulty;
@@ -204,7 +206,7 @@ fn parse_args() -> CliParsedArgs {
             // now parse to the supported args
             match arg_name {
                 "difficulty" => parsed_args.difficulty = arg_value.parse().unwrap(),
-                "vanity" => parsed_args.vanity_prefix = arg_value,
+                "vanity" => parsed_args.vanity_prefix = arg_value.to_lowercase(),
                 _ => println!("Argument '{arg_name}' not supported. Ignored"),
             }
         }
@@ -216,6 +218,13 @@ fn parse_args() -> CliParsedArgs {
     }
     if parsed_args.vanity_prefix.len() > 32 {
         panic!("The vanity prefix cannot be longer than 32 characters.");
+    }
+    if parsed_args.vanity_prefix.len() > 0 {
+        // check valid hexa characters
+        let hex_re = Regex::new(r"^([0-9a-f]*)$").unwrap();
+        if !hex_re.is_match(parsed_args.vanity_prefix.as_str()) {
+            panic!("The vanity prefix can only contain hexadecimal characters.");
+        }
     }
 
     // println!("Diff: {}", cli_args.difficulty);

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut difficulty = parsed_args.difficulty;
     let vanity_prefix = parsed_args.vanity_prefix;
+    let vanity_npub_prefix = parsed_args.vanity_npub_prefix;
     // initially the same as difficulty
     let mut pow_difficulty = difficulty;
 
@@ -29,6 +30,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!(
             "Started mining process for a vanify prefix of: {} (pow: {})",
             vanity_prefix, pow_difficulty
+        );
+    } else if vanity_npub_prefix != "" {
+        // set pow difficulty as the length of the prefix translated to bits
+        pow_difficulty = (vanity_npub_prefix.len() * 4) as u8;
+        println!(
+            "Started mining process for a vanify npub prefix of: {} (pow: {})",
+            vanity_npub_prefix, pow_difficulty
         );
     } else {
         // Defaults to using difficulty
@@ -48,9 +56,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let cores = num_cpus::get();
 
     // benchmark cores
-    benchmark_cores(cores, pow_difficulty);
+    if vanity_npub_prefix != "" {
+        println!("Benchmarking of cores disabled for vanity npub key upon proper calculation.");
+    } else {
+        benchmark_cores(cores, pow_difficulty);
+    }
 
-    // Loop: generate public keys until desired number of leading zeroes is reached
+    // Loop: generate public keys until desired public key is reached
     let now = Instant::now();
 
     println!("Mining using {cores} cores...");
@@ -58,11 +70,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     // thread safe variables
     let best_diff = Arc::new(AtomicU8::new(pow_difficulty));
     let vanity_ts = Arc::new(vanity_prefix);
+    let vanity_npub_ts = Arc::new(vanity_npub_prefix);
     let iterations = Arc::new(AtomicU64::new(0));
 
     for _ in 0..cores {
         let best_diff = best_diff.clone();
         let vanity_ts = vanity_ts.clone();
+        let vanity_npub_ts = vanity_npub_ts.clone();
         let iterations = iterations.clone();
         thread::spawn(move || {
             let mut rng = thread_rng();
@@ -76,9 +90,23 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let mut leading_zeroes = 0;
 
                 // check pubkey validity depending on arg settings
-                let is_valid_pubkey: bool;
-                if vanity_ts.as_str() != "" {
-                    is_valid_pubkey = xonly_public_key.to_hex().starts_with(vanity_ts.as_str());
+                let mut is_valid_pubkey: bool = false;
+                if vanity_ts.as_str() != "" || vanity_npub_ts.as_str() != "" {
+                    let hexa_key = xonly_public_key.to_hex();
+                    if vanity_ts.as_str() != "" {
+                        is_valid_pubkey = hexa_key.starts_with(vanity_ts.as_str());
+                    } else if vanity_npub_ts.as_str() != "" {
+                        let bech_key: String = bech32::encode(
+                            "npub",
+                            hex::decode(hexa_key).unwrap().to_base32(),
+                            Variant::Bech32,
+                        )
+                        .unwrap();
+
+                        is_valid_pubkey = bech_key.starts_with(
+                            (String::from("npub1") + vanity_npub_ts.as_str()).as_str(),
+                        );
+                    }
                 } else {
                     leading_zeroes = get_leading_zero_bits(&xonly_public_key.serialize());
                     is_valid_pubkey = leading_zeroes > best_diff.load(Ordering::Relaxed);
@@ -195,13 +223,15 @@ fn get_leading_zero_bits(bytes: &[u8]) -> u8 {
 struct CliParsedArgs {
     difficulty: u8,
     vanity_prefix: String,
+    vanity_npub_prefix: String,
 }
 
 /// Parse and structure the CLI arguments
 fn parse_args() -> CliParsedArgs {
     let mut parsed_args = CliParsedArgs {
-        difficulty: 0,                 // empty/disabled
-        vanity_prefix: "".to_string(), // empty/disabled
+        difficulty: 0,                      // empty/disabled
+        vanity_prefix: "".to_string(),      // empty/disabled
+        vanity_npub_prefix: "".to_string(), // empty/disabled
     };
     let args: Vec<String> = env::args().collect();
 
@@ -218,23 +248,37 @@ fn parse_args() -> CliParsedArgs {
             match arg_name {
                 "difficulty" => parsed_args.difficulty = arg_value.parse().unwrap(),
                 "vanity" => parsed_args.vanity_prefix = arg_value.to_lowercase(),
+                "vanity-n" => parsed_args.vanity_npub_prefix = arg_value.to_lowercase(),
                 _ => println!("Argument '{arg_name}' not supported. Ignored"),
             }
         }
     }
 
     // validation
-    if parsed_args.difficulty > 0 && parsed_args.vanity_prefix != "" {
-        panic!("You cannot set a difficulty and a vanity prefix at the same time.");
+    if parsed_args.difficulty > 0
+        && parsed_args.vanity_prefix != ""
+        && parsed_args.vanity_npub_prefix != ""
+    {
+        panic!("You can only specify one generation condition at a time.");
     }
-    if parsed_args.vanity_prefix.len() > 32 {
-        panic!("The vanity prefix cannot be longer than 32 characters.");
+    if parsed_args.vanity_prefix.len() > 64 {
+        panic!("The vanity prefix cannot be longer than 64 characters.");
     }
     if parsed_args.vanity_prefix.len() > 0 {
         // check valid hexa characters
         let hex_re = Regex::new(r"^([0-9a-f]*)$").unwrap();
         if !hex_re.is_match(parsed_args.vanity_prefix.as_str()) {
             panic!("The vanity prefix can only contain hexadecimal characters.");
+        }
+    }
+    if parsed_args.vanity_npub_prefix.len() > 59 {
+        panic!("The vanity npub prefix cannot be longer than 59 characters.");
+    }
+    if parsed_args.vanity_npub_prefix.len() > 0 {
+        // check valid hexa characters
+        let hex_re = Regex::new(r"^([02-9ac-hj-np-z]*)$").unwrap();
+        if !hex_re.is_match(parsed_args.vanity_npub_prefix.as_str()) {
+            panic!("The vanity npub prefix can only contain characters supported by Bech32.");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
 
+const DIFFICULTY_DEFAULT: u8 = 10;
+
 fn main() -> Result<(), Box<dyn Error>> {
     // Parse CLI arguments
     // let args: Vec<String> = env::args().collect();
@@ -30,8 +32,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
     } else {
         // Defaults to using difficulty
+
+        // if difficulty not indicated, then assume default
         if difficulty == 0 {
-            difficulty = 10; // default
+            difficulty = DIFFICULTY_DEFAULT; // default
             pow_difficulty = difficulty;
         }
 
@@ -42,28 +46,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let cores = num_cpus::get();
-    let mut hashes_per_second_per_core = 0;
 
-    println!("Benchmarking a single core for 5 seconds...");
-    let now = Instant::now();
-    let secp = Secp256k1::new();
-    let mut rng = thread_rng();
-    loop {
-        let (_secret_key, public_key) = secp.generate_keypair(&mut rng);
-        let (xonly_public_key, _) = public_key.x_only_public_key();
-        let _leading_zeroes = get_leading_zero_bits(&xonly_public_key.serialize());
-        hashes_per_second_per_core += 1;
-        if now.elapsed().as_secs() > 5 {
-            break;
-        }
-    }
-    hashes_per_second_per_core /= 10;
-    println!("A single core can mine roughly {hashes_per_second_per_core} h/s!");
-
-    let estimated_hashes = 2_u128.pow(pow_difficulty as u32);
-    println!("Searching for prefix of {pow_difficulty} specific bits");
-    let estimate = estimated_hashes as f32 / hashes_per_second_per_core as f32 / cores as f32;
-    println!("This is estimated to take about {estimate} seconds");
+    // benchmark cores
+    benchmark_cores(cores, pow_difficulty);
 
     // Loop: generate public keys until desired number of leading zeroes is reached
     let now = Instant::now();
@@ -136,6 +121,32 @@ fn main() -> Result<(), Box<dyn Error>> {
     loop {
         thread::sleep(std::time::Duration::from_secs(3600));
     }
+}
+
+/// Benchmark the cores capabilities for key generation
+fn benchmark_cores(cores: usize, pow_difficulty: u8) {
+    let mut hashes_per_second_per_core = 0;
+
+    println!("Benchmarking a single core for 5 seconds...");
+    let now = Instant::now();
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+    loop {
+        let (_secret_key, public_key) = secp.generate_keypair(&mut rng);
+        let (xonly_public_key, _) = public_key.x_only_public_key();
+        get_leading_zero_bits(&xonly_public_key.serialize());
+        hashes_per_second_per_core += 1;
+        if now.elapsed().as_secs() > 5 {
+            break;
+        }
+    }
+    hashes_per_second_per_core /= 10;
+    println!("A single core can mine roughly {hashes_per_second_per_core} h/s!");
+
+    let estimated_hashes = 2_u128.pow(pow_difficulty as u32);
+    println!("Searching for prefix of {pow_difficulty} specific bits");
+    let estimate = estimated_hashes as f32 / hashes_per_second_per_core as f32 / cores as f32;
+    println!("This is estimated to take about {estimate} seconds");
 }
 
 /// Print private and public keys to the output


### PR DESCRIPTION
You want it, you've got it :sunglasses: 
This PR allows the user to specify a vanity prefix for the npub format. To be more specific, what comes after `npub1`.

The new option is `--vanity-n`, and it can be combined with `--vanity` if someone wants prefixes in both outputs. However, this takes much more processing power to achieve.

Other changes:
- README doc was updated
- Small code refactor was made
- Additional validations for inputs were introduced