### PR TITLE
Adds --cores option to limit to `num_cores`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,9 +44,16 @@ in npub format (Bech32 encoding). Specify multiple vanity
 targets as a comma-separated list."
     )]
     pub vanity_npub_prefixes_raw_input: String,
+    #[arg(
+        short = 'c',
+        long = "cores",
+        default_value_t = num_cpus::get(),
+        help = "Number of processor cores to use"
+    )]
+    pub num_cores: usize,
 }
 
-pub fn check_args(difficulty: u8, vanity_prefix: &str, vanity_npub_prefixes: &Vec<String>) {
+pub fn check_args(difficulty: u8, vanity_prefix: &str, vanity_npub_prefixes: &Vec<String>, num_cores: usize) {
     // Check the public key requirements
     let mut requirements_count: u8 = 0;
     if difficulty > 0 {
@@ -84,6 +91,12 @@ pub fn check_args(difficulty: u8, vanity_prefix: &str, vanity_npub_prefixes: &Ve
         if vanity_npub_prefix.len() > 59 {
             panic!("The vanity npub prefix cannot be longer than 59 characters.");
         }
+    }
+
+    if num_cores == 0 {
+        panic!("There can be no proof of work if one does not do work (-c, --cores must be greater than 0)");
+    } else if num_cores > num_cpus::get() {
+        panic!("Your processor has {} cores; cannot set -c, --cores to {}", num_cpus::get(), num_cores);
     }
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut difficulty = parsed_args.difficulty;
     let vanity_prefix = parsed_args.vanity_prefix;
     let mut vanity_npub_prefixes = <Vec<String>>::new();
+    let num_cores = parsed_args.num_cores;
 
     for vanity_npub in parsed_args.vanity_npub_prefixes_raw_input.split(',') {
         if !vanity_npub.is_empty() {
@@ -28,7 +29,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    check_args(difficulty, vanity_prefix.as_str(), &vanity_npub_prefixes);
+    check_args(difficulty, vanity_prefix.as_str(), &vanity_npub_prefixes, num_cores);
 
     //-- Calculate pow difficulty and initialize
 
@@ -69,19 +70,17 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
     }
 
-    let cores = num_cpus::get();
-
     // benchmark cores
     if !vanity_npub_prefixes.is_empty() {
         println!("Benchmarking of cores disabled for vanity npub key upon proper calculation.");
     } else {
-        benchmark_cores(cores, pow_difficulty);
+        benchmark_cores(num_cores, pow_difficulty);
     }
 
     // Loop: generate public keys until desired public key is reached
     let now = Instant::now();
 
-    println!("Mining using {cores} cores...");
+    println!("Mining using {num_cores} cores...");
 
     // thread safe variables
     let best_diff = Arc::new(AtomicU8::new(pow_difficulty));
@@ -90,7 +89,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let iterations = Arc::new(AtomicU64::new(0));
 
     // start a thread for each core for calculations
-    for _ in 0..cores {
+    for _ in 0..num_cores {
         let best_diff = best_diff.clone();
         let vanity_ts = vanity_ts.clone();
         let vanity_npubs_ts = vanity_npubs_ts.clone();


### PR DESCRIPTION
Additional usage option:
```
  -c, --cores <NUM_CORES>
          Number of processor cores to use [default: 8]
```
_note: actual default number of cores will depend on each machine_

Validates against actual number of processor cores onboard. Must range from > 0 to <= `num_cpus::get()`.

Rationale: Would be nice to keep grinding in the background while running other processor-heavy tasks (e.g. Docker) by keeping some cores free.