### PR TITLE
Add features: Exit after match and benchmark only flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "rana"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bech32",
  "bitcoin_hashes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "rana"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bech32",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rana"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <fjcalderon@gmail.com>"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,14 @@ targets as a comma-separated list."
         help = "Run only benchmarking then quit"
     )]
     pub benchmark_only: bool,
+    #[arg(
+        short,
+        long = "exit-after",
+        required = false,
+        default_value_t = false,
+        help = "Exit after a key pair is found"
+    )]
+    pub exit_after_find: bool,
 }
 
 pub fn check_args(difficulty: u8, vanity_prefix: &str, vanity_npub_prefixes: &Vec<String>, num_cores: usize) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,6 +51,14 @@ targets as a comma-separated list."
         help = "Number of processor cores to use"
     )]
     pub num_cores: usize,
+    #[arg(
+        short,
+        long = "bench-only",
+        required = false,
+        default_value_t = false,
+        help = "Run only benchmarking then quit"
+    )]
+    pub benchmark_only: bool,
 }
 
 pub fn check_args(difficulty: u8, vanity_prefix: &str, vanity_npub_prefixes: &Vec<String>, num_cores: usize) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
+use std::process::exit;
 
 const DIFFICULTY_DEFAULT: u8 = 10;
 
@@ -22,6 +23,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let vanity_prefix = parsed_args.vanity_prefix;
     let mut vanity_npub_prefixes = <Vec<String>>::new();
     let num_cores = parsed_args.num_cores;
+    let benchmark_only = parsed_args.benchmark_only;
 
     for vanity_npub in parsed_args.vanity_npub_prefixes_raw_input.split(',') {
         if !vanity_npub.is_empty() {
@@ -70,8 +72,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     // benchmark cores
     if !vanity_npub_prefixes.is_empty() {
         println!("Benchmarking of cores disabled for vanity npub key upon proper calculation.");
-    } else {
+    }  else {
         benchmark_cores(num_cores, pow_difficulty);
+    }
+
+    if vanity_npub_prefixes.is_empty() && benchmark_only {
+        println!("Benchmark only flag is enabled. Exiting.");
+        exit(0);
     }
 
     // Loop: generate public keys until desired public key is reached


### PR DESCRIPTION
I've added these features in preparation for running rana in a docker container.

- `--bench-only` Qquit after benchmarking a single core.
- `--exit-after` Exit the program after finding a match.
  - NOTE: Limitation is applied to each core/thread
- Adds handler for thread completion