### PR TITLE
Add ability to specify suffix for npub

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,7 @@ as hexadecimal."
     pub vanity_prefix: String,
     #[arg(
         short = 'n',
-        long = "vanity-n",
+        long = "vanity-n-prefix",
         required = false,
         default_value = "",
         help = "Enter the prefix your public key should have when expressed
@@ -44,6 +44,16 @@ in npub format (Bech32 encoding). Specify multiple vanity
 targets as a comma-separated list."
     )]
     pub vanity_npub_prefixes_raw_input: String,
+    #[arg(
+        short = 's',
+        long = "vanity-n-suffix",
+        required = false,
+        default_value = "",
+        help = "Enter the suffix your public key should have when expressed
+in npub format (Bech32 encoding). Specify multiple vanity
+targets as a comma-separated list."
+    )]
+    pub vanity_npub_suffixes_raw_input: String,
     #[arg(
         short = 'c',
         long = "cores",
@@ -53,7 +63,7 @@ targets as a comma-separated list."
     pub num_cores: usize,
 }
 
-pub fn check_args(difficulty: u8, vanity_prefix: &str, vanity_npub_prefixes: &Vec<String>, num_cores: usize) {
+pub fn check_args(difficulty: u8, vanity_prefix: &str, vanity_npub_prefixes: &Vec<String>, vanity_npub_suffixes: &Vec<String>, num_cores: usize) {
     // Check the public key requirements
     let mut requirements_count: u8 = 0;
     if difficulty > 0 {
@@ -62,9 +72,10 @@ pub fn check_args(difficulty: u8, vanity_prefix: &str, vanity_npub_prefixes: &Ve
     if !vanity_prefix.is_empty() {
         requirements_count += 1;
     }
-    if !vanity_npub_prefixes.is_empty() {
+    if !vanity_npub_prefixes.is_empty() || !vanity_npub_suffixes.is_empty() {
         requirements_count += 1;
     }
+
     if requirements_count > 1 {
         panic!("You can cannot specify more than one requirement. You should choose between difficulty or any of the vanity formats.");
     }
@@ -90,6 +101,18 @@ pub fn check_args(difficulty: u8, vanity_prefix: &str, vanity_npub_prefixes: &Ve
         }
         if vanity_npub_prefix.len() > 59 {
             panic!("The vanity npub prefix cannot be longer than 59 characters.");
+        }
+    }
+
+    for vanity_npub_suffix in vanity_npub_suffixes {
+        if !vanity_npub_suffix.is_empty() {
+            let hex_re = Regex::new(r"^([02-9ac-hj-np-z]*)$").unwrap();
+            if !hex_re.is_match(vanity_npub_suffix.as_str()) {
+                panic!("The vanity npub suffix can only contain characters supported by Bech32: 023456789acdefghjklmnpqrstuvwxyz");
+            }
+        }
+        if vanity_npub_suffix.len() > 59 {
+            panic!("The vanity npub suffix cannot be longer than 59 characters.");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,15 +131,16 @@ fn main() -> Result<(), Box<dyn Error>> {
                     if !vanity_npubs_pre_ts.is_empty() && !vanity_npubs_post_ts.is_empty() {
                         for cur_vanity_npub_pre in vanity_npubs_pre_ts.iter() {
                             for cur_vanity_npub_post in vanity_npubs_post_ts.iter() {
-                            is_valid_pubkey = bech_key.starts_with(
-                                (String::from("npub1") + cur_vanity_npub_pre.as_str()).as_str(),
-                            ) && bech_key.ends_with(cur_vanity_npub_post.as_str());
+                                is_valid_pubkey = bech_key.starts_with(
+                                    (String::from("npub1") + cur_vanity_npub_pre.as_str()).as_str(),
+                                ) && bech_key.ends_with(cur_vanity_npub_post.as_str());
 
-                            if is_valid_pubkey {
-                                vanity_npub = cur_vanity_npub_pre.clone() + "..." + cur_vanity_npub_post.clone().as_str();
-                                break;
+                                if is_valid_pubkey {
+                                    vanity_npub = cur_vanity_npub_pre.clone() + "..." + cur_vanity_npub_post.clone().as_str();
+                                    break;
+                                }
                             }
-                        }
+                            if is_valid_pubkey {break;}
                         }
                     }
                     else if !vanity_npubs_pre_ts.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,15 +21,21 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut difficulty = parsed_args.difficulty;
     let vanity_prefix = parsed_args.vanity_prefix;
     let mut vanity_npub_prefixes = <Vec<String>>::new();
+    let mut vanity_npub_suffixes = <Vec<String>>::new();
     let num_cores = parsed_args.num_cores;
 
-    for vanity_npub in parsed_args.vanity_npub_prefixes_raw_input.split(',') {
-        if !vanity_npub.is_empty() {
-            vanity_npub_prefixes.push(vanity_npub.to_string())
+    for vanity_npub_pre in parsed_args.vanity_npub_prefixes_raw_input.split(',') {
+        if !vanity_npub_pre.is_empty() {
+            vanity_npub_prefixes.push(vanity_npub_pre.to_string())
+        }
+    }
+    for vanity_npub_post in parsed_args.vanity_npub_suffixes_raw_input.split(',') {
+        if !vanity_npub_post.is_empty() {
+            vanity_npub_suffixes.push(vanity_npub_post.to_string())
         }
     }
 
-    check_args(difficulty, vanity_prefix.as_str(), &vanity_npub_prefixes, num_cores);
+    check_args(difficulty, vanity_prefix.as_str(), &vanity_npub_prefixes, &vanity_npub_suffixes, num_cores);
 
     //-- Calculate pow difficulty and initialize
 
@@ -68,7 +74,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // benchmark cores
-    if !vanity_npub_prefixes.is_empty() {
+    if !vanity_npub_prefixes.is_empty() || !vanity_npub_suffixes.is_empty() {
         println!("Benchmarking of cores disabled for vanity npub key upon proper calculation.");
     } else {
         benchmark_cores(num_cores, pow_difficulty);
@@ -82,14 +88,16 @@ fn main() -> Result<(), Box<dyn Error>> {
     // thread safe variables
     let best_diff = Arc::new(AtomicU8::new(pow_difficulty));
     let vanity_ts = Arc::new(vanity_prefix);
-    let vanity_npubs_ts = Arc::new(vanity_npub_prefixes);
+    let vanity_npubs_pre_ts = Arc::new(vanity_npub_prefixes);
+    let vanity_npubs_post_ts = Arc::new(vanity_npub_suffixes);
     let iterations = Arc::new(AtomicU64::new(0));
 
     // start a thread for each core for calculations
     for _ in 0..num_cores {
         let best_diff = best_diff.clone();
         let vanity_ts = vanity_ts.clone();
-        let vanity_npubs_ts = vanity_npubs_ts.clone();
+        let vanity_npubs_pre_ts = vanity_npubs_pre_ts.clone();
+        let vanity_npubs_post_ts = vanity_npubs_post_ts.clone();
         let iterations = iterations.clone();
         thread::spawn(move || {
             let mut rng = thread_rng();
@@ -111,7 +119,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     // hex vanity search
                     is_valid_pubkey = hexa_key.starts_with(vanity_ts.as_str());
 
-                } else if !vanity_npubs_ts.is_empty() {
+                } else if !vanity_npubs_pre_ts.is_empty() || !vanity_npubs_post_ts.is_empty() {
                     // bech32 vanity search
                     let bech_key: String = bech32::encode(
                         "npub",
@@ -120,14 +128,40 @@ fn main() -> Result<(), Box<dyn Error>> {
                     )
                     .unwrap();
 
-                    for cur_vanity_npub in vanity_npubs_ts.iter() {
-                        is_valid_pubkey = bech_key.starts_with(
-                            (String::from("npub1") + cur_vanity_npub.as_str()).as_str(),
-                        );
+                    if !vanity_npubs_pre_ts.is_empty() && !vanity_npubs_post_ts.is_empty() {
+                        for cur_vanity_npub_pre in vanity_npubs_pre_ts.iter() {
+                            for cur_vanity_npub_post in vanity_npubs_post_ts.iter() {
+                            is_valid_pubkey = bech_key.starts_with(
+                                (String::from("npub1") + cur_vanity_npub_pre.as_str()).as_str(),
+                            ) && bech_key.ends_with(cur_vanity_npub_post.as_str());
 
-                        if is_valid_pubkey {
-                            vanity_npub = cur_vanity_npub.clone();
-                            break;
+                            if is_valid_pubkey {
+                                vanity_npub = cur_vanity_npub_pre.clone() + "..." + cur_vanity_npub_post.clone().as_str();
+                                break;
+                            }
+                        }
+                        }
+                    }
+                    else if !vanity_npubs_pre_ts.is_empty() {
+                        for cur_vanity_npub in vanity_npubs_pre_ts.iter() {
+                            is_valid_pubkey = bech_key.starts_with(
+                                (String::from("npub1") + cur_vanity_npub.as_str()).as_str(),
+                            );
+
+                            if is_valid_pubkey {
+                                vanity_npub = cur_vanity_npub.clone();
+                                break;
+                            }
+                        }
+                    }
+                    else {
+                        for cur_vanity_npub in vanity_npubs_post_ts.iter() {
+                            is_valid_pubkey = bech_key.ends_with(cur_vanity_npub.as_str());
+
+                            if is_valid_pubkey {
+                                vanity_npub = cur_vanity_npub.clone();
+                                break;
+                            }
                         }
                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,12 +50,28 @@ fn main() -> Result<(), Box<dyn Error>> {
             vanity_prefix, pow_difficulty
         );
 
+    } else if !vanity_npub_prefixes.is_empty() && !vanity_npub_suffixes.is_empty() {
+        // set pow difficulty as the length of the first prefix + first suffix translated to bits
+        pow_difficulty = ((vanity_npub_prefixes[0].len() * 4) + (vanity_npub_suffixes[0].len() * 4)) as u8;
+        println!(
+            "Started mining process for vanity bech32 prefix[es]: 'npub1{:?}' and suffix[es]: '...{:?}' (estimated pow: {})",
+            vanity_npub_prefixes, vanity_npub_suffixes, pow_difficulty
+        );
+
     } else if !vanity_npub_prefixes.is_empty() {
         // set pow difficulty as the length of the first prefix translated to bits
         pow_difficulty = (vanity_npub_prefixes[0].len() * 4) as u8;
         println!(
             "Started mining process for vanity bech32 prefix[es]: 'npub1{:?}' (estimated pow: {})",
             vanity_npub_prefixes, pow_difficulty
+        );
+
+    } else if !vanity_npub_suffixes.is_empty() {
+        // set pow difficulty as the length of the first suffix translated to bits
+        pow_difficulty = (vanity_npub_suffixes[0].len() * 4) as u8;
+        println!(
+            "Started mining process for vanity bech32 suffix[es]: '...{:?}' (estimated pow: {})",
+            vanity_npub_suffixes, pow_difficulty
         );
 
     } else {


### PR DESCRIPTION
Fixes  #11

Users can now specify an -s flag to search for a given list of suffixes. This works alongside the -n flag, so users can specify both a prefix and a suffix at the same time.