### PR TITLE
Simplify handling of default difficulty

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ pub struct CLIArgs {
     #[arg(
         short,
         long,
-        default_value_t = 0,
+        default_value_t = crate::DIFFICULTY_DEFAULT,
         help = "Enter the number of starting bits that should be 0."
     )]
     pub difficulty: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,5 @@ pub mod cli;
 pub mod mnemonic;
 pub mod tests;
 pub mod utils;
+
+pub(crate) const DIFFICULTY_DEFAULT: u8 = 10;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use rana::cli::*;
 use rana::mnemonic::handle_mnemonic;
 use rana::utils::{benchmark_cores, get_leading_zero_bits, print_divider, print_keys, print_qr};
 
-const DIFFICULTY_DEFAULT: u8 = 10;
 const BECH32_PREFIX: &str = "npub1";
 
 fn main() -> Result<()> {
@@ -24,7 +23,7 @@ fn main() -> Result<()> {
         handle_mnemonic(&parsed_args);
     }
 
-    let mut difficulty: u8 = parsed_args.difficulty;
+    let difficulty: u8 = parsed_args.difficulty;
     let vanity_prefix: String = parsed_args.vanity_prefix;
     let mut vanity_npub_prefixes: Vec<String> = Vec::new();
     let mut vanity_npub_suffixes: Vec<String> = Vec::new();
@@ -81,13 +80,6 @@ fn main() -> Result<()> {
         );
     } else {
         // Defaults to using difficulty
-
-        // if difficulty not indicated, then assume default
-        if difficulty == 0 {
-            difficulty = DIFFICULTY_DEFAULT; // default
-            pow_difficulty = difficulty;
-        }
-
         println!(
             "Started mining process with a difficulty of: {difficulty} (pow: {pow_difficulty})"
         );


### PR DESCRIPTION
Moved `DIFFICULTY_DEFAULT` to the lib root, so it can be referenced in the CLI arg annotations.