### PR TITLE
Enable file binary creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/grunch/rana"
 keywords = ["nostr", "mining", "pubkeys", "bech32"]
 readme = "README.md"
 
+[[bin]]
+name = "rana"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "4.0.15", features = ["env", "default", "derive"] }
 regex = "1"


### PR DESCRIPTION
🥳 Binary creation is possible using only this command and the commit I made:

`cargo build --release --target-dir .`

The binary is going to be created under **release** directory.
The arch will be the same as the host machine. In my case:

**rana: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=65b4d3fad4caae109ebab35238a0731124f9b80e, for GNU/Linux 3.2.0, with debug_info, not stripped**