### PR TITLE
Duplicated arch removed and musl instead GNU

### DIFF
--- a/archs
+++ b/archs
@@ -1,7 +1,6 @@
-aarch64-unknown-linux-gnu
 arm-unknown-linux-gnueabi
-x86_64-unknown-linux-gnu
-aarch64-unknown-linux-gnu
+x86_64-unknown-linux-musl
+aarch64-unknown-linux-musl
 armv7-unknown-linux-gnueabi
 x86_64-linux-android
 x86_64-pc-windows-gnu


### PR DESCRIPTION
- Duplicated arch removed
- When building with musl we avoid having glibc issues due incompatible versions on different operating systems


More information and commentaries are in this PR: https://github.com/grunch/rana/pull/44#issuecomment-1665463765

If you face any problems when building aarch64 for musl, this is a great tool: https://github.com/grunch/rana/pull/44#issuecomment-1662734887